### PR TITLE
add platformio_override.ini as personal config override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .vscode/ipch
 .vscode/settings.json
 platformio-device-monitor*.log
+platformio_override.ini

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Use a power suppy with 5 V and 1 A. The USB cable connected to your PC/Notebook 
 
 ### Change pin assignment
 Its possible to change all the pins of the NRF24L01+ module.
-This can be achieved by editing the 'platformio.ini' file and add/change one or more of the following lines to the 'build_flags' parameter:
+This can be achieved by copying one of the [env:....] sections from 'platformio.ini' to 'platformio_override.ini' and editing the 'platformio_override.ini' file and add/change one or more of the following lines to the 'build_flags' parameter:
 ```
 -DHOYMILES_PIN_MISO=19
 -DHOYMILES_PIN_MOSI=23
@@ -105,6 +105,7 @@ This can be achieved by editing the 'platformio.ini' file and add/change one or 
 -DHOYMILES_PIN_CE=4
 -DHOYMILES_PIN_CS=5
 ```
+It is recommended to make all changes only in the  'platformio_override.ini', this is your personal copy.
 
 ## Flashing and starting up
 ### with Visual Studio Code
@@ -112,8 +113,8 @@ This can be achieved by editing the 'platformio.ini' file and add/change one or 
 * In Visual Studio Code, install the [PlatformIO Extension](https://marketplace.visualstudio.com/items?itemName=platformio.platformio-ide)
 * Install git and enable git in vscode - [git download](https://git-scm.com/downloads/) - [Instructions](https://www.jcchouinard.com/install-git-in-vscode/)
 * Clone this repository (you really have to clone it, don't just download the ZIP file. During the build process the git hash gets embedded into the firmware. If you download the ZIP file a build error will occur): Inside vscode open the command palette by pressing `CTRL` + `SHIFT` + `P`. Enter `git clone`, add the repository-URL `https://github.com/tbnobody/OpenDTU`. Next you have to choose (or create) a target directory.
-* In vscode, choose File --> Open Folder and select the previously downloaded source code. (You have to select the folder which contains the "platformio.ini" file)
-* Adjust the COM port in the file "platformio.ini" for your USB-serial-converter. It occurs twice:
+* In vscode, choose File --> Open Folder and select the previously downloaded source code. (You have to select the folder which contains the "platformio.ini" and "platformio_override.ini" file)
+* Adjust the COM port in the file "platformio_override.ini" for your USB-to-serial-converter. It occurs twice:
     * upload_port
     * monitor_port
 * Select the arrow button in the blue bottom status bar (PlatformIO: Upload) to compile and upload the firmware. During the compilation, all required libraries are downloaded automatically.
@@ -124,7 +125,7 @@ This can be achieved by editing the 'platformio.ini' file and add/change one or 
 ### on the commandline with PlatformIO Core
 * Install [PlatformIO Core](https://platformio.org/install/cli)
 * Clone this repository (you really have to clone it, don't just download the ZIP file. During the build process the git hash gets embedded into the firmware. If you download the ZIP file a build error will occur)
-* Adjust the COM port in the file "platformio.ini". It occurs twice:
+* Adjust the COM port in the file "platformio_override.ini". It occurs twice:
     * upload_port
     * monitor_port
 * build: `platformio run -e generic`

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,8 @@
 
 [platformio]
 default_envs = generic
+extra_configs =
+    platformio_override.ini
 
 [env]
 framework = arduino
@@ -35,9 +37,9 @@ monitor_filters = esp32_exception_decoder, time, log2file, colorize
 monitor_speed = 115200
 upload_protocol = esptool
 
-; Specify port here. Comment out (add ; in front of line) to use auto detection.
-monitor_port = COM4
-upload_port = COM4
+; Specify port in platformio_override.ini. Comment out (add ; in front of line) to use auto detection.
+; monitor_port = COM4
+; upload_port = COM4
 
 
 [env:generic]

--- a/platformio_override.ini
+++ b/platformio_override.ini
@@ -1,0 +1,31 @@
+; ***  PlatformIO Project Configuration Override File   ***
+; ***  Changes done here override settings in platformio.ini    ***
+;
+; Place your personal settings like monitor_port and upload_port here
+; instead of editing platformio.ini
+; to avoid annoying merge conflicts when you pull updates into your
+; personal clone of the repository
+;
+; Please visit documentation for the options and examples
+; http://docs.platformio.org/en/stable/projectconf.html
+
+[env]
+; Specify port here. Comment out (add ; in front of line) to use auto detection.
+monitor_port = COM4
+upload_port = COM4
+
+
+; you can define your personal board and/or settings here
+; non functional example:
+
+;[env:my_very_special_board]
+;board = esp32dev
+;build_flags = ${env.build_flags}
+;    -DHOYMILES_PIN_MISO=1
+;    -DHOYMILES_PIN_MOSI=2
+;    -DHOYMILES_PIN_SCLK=3
+;    -DHOYMILES_PIN_IRQ=4
+;    -DHOYMILES_PIN_CE=5
+;    -DHOYMILES_PIN_CS=6
+;monitor_port = /dev/ttyACM0
+;upload_port = /dev/ttyACM0


### PR DESCRIPTION
Personal edits in platformio.ini causes annoying merge conflicts then new commits are pulled from upstream. Adding an personal override config which is further ignored from git will avoid this.

Signed-off-by: Martin Dummer <martin.dummer@gmx.net>